### PR TITLE
fix issue with background not loading without refresh

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -7,21 +7,30 @@ class Background {
     this.img.src = url
     this.x = 0
     this.height = this.ctx.canvas.height
-    this.width = this.height*this.img.width/this.img.height
   }
   update() {
     this.x -= this.speed
-    if (this.x < -this.width) {
-      this.x += this.width
+    if (this.x < -this.width()) {
+      this.x += this.width()
     }
   }
   stop(){
     this.x = 0
-    
+
+  }
+  /*
+  /  width() has to be a function because when you initially load the image
+  /  `this.img.width` and `this.img.height` are both 0
+  /  this leads to a division by 0 and width gets set to `NaN`
+  /
+  /  Another soluton could be to only set the width after the image has loaded
+  */
+  width() {
+    return this.height*this.img.width/this.img.height;
   }
   draw() {
-    for (var i = 0; this.x+i*this.width < this.ctx.canvas.width; i++) {
-      this.ctx.drawImage(this.img,this.x+i*this.width,0,this.width,this.height)
+    for (var i = 0; this.x+i*this.width() < this.ctx.canvas.width; i++) {
+      this.ctx.drawImage(this.img,this.x+i*this.width(),0,this.width(),this.height)
     }
   }
 }


### PR DESCRIPTION
@SplitSeconds This PR fixes the issue where you would need to refresh the page to get the background to load properly.

### The Issue

Essentially when you first set `this.img.src` in `background.js` `this.img.width` and `this.img.height` are both `0`.

So this line `this.width = this.height*this.img.width/this.img.height` was setting `this.width` to `NaN` (because of the division by `0`)

This means that in the for loop `for (var i = 0; this.x+i*this.width < this.ctx.canvas.width; i++) {` `this.x+I*this.width` was _also_ `NaN` and `NaN < 1200` happens to be `false` which means you'd never actually enter the for loop.

This was fixed after the page was loaded once because the image was cached -- so the browser was able to load the image and set the height before `this.width = ...` was being called.

### The Fix

Instead of setting the width on load -- calculate the width every time we need it

### Testing

Cleared my cache, loaded the page once, clicked start, and saw the background appear as normal 👍 